### PR TITLE
Fix/invalid tx

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "bigi": "^1.4.2",
-    "bitcoinjs-lib": "^4.0.2",
+    "bitcoinjs-lib": "^4.0.5",
     "blockstack": "^18.1.0",
     "c32check": "^0.0.6",
     "crypto": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockstack/stacks-utils",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Utilities for the Stacks blockchain.",
   "scripts": {
     "build": "microbundle",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -70,15 +70,15 @@ const fetchStacksAddressData = async stacksAddress => {
   // decode the raw tx to get at the stacks data
   const transactionsWithStacksData = await decodeRawTxs(txs, false);
 
+  const history = (data && data.history) ? data.history : [];
+
   // determine if the stacks transaction is valid or not (accepted by Blockstack Core)
   const transactionsWithStacksDataWithInvalidState = transactionsWithStacksData.map(
     tx => ({
       ...tx,
       invalid:
-        Number(tx.confirmations) >= 7 &&
-        data &&
-        data.history &&
-        !data.history.find(historical => historical.txid === tx.txid) // if this is true, and has 7+ confirmations, it's an invalid stacks tx
+        Number(tx.confirmations) >= 10 &&
+        !history.find(historical => historical.txid === tx.txid) // if this is true, and has 10+ confirmations, it's an invalid stacks tx
     })
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -333,6 +333,18 @@ bip32@^1.0.0, bip32@^1.0.2:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
+bip32@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-1.0.4.tgz#188ad57a45fb1342c9aabe969d0612c704a987b4"
+  integrity sha512-8T21eLWylZETolyqCPgia+MNp+kY37zFr7PTFDTPObHeNi9JlfG4qGIh8WzerIJidtwoK+NsWq2I5i66YfHoIw==
+  dependencies:
+    bs58check "^2.1.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    tiny-secp256k1 "^1.0.0"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
 bip39@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.5.0.tgz#51cbd5179460504a63ea3c000db3f787ca051235"
@@ -356,13 +368,34 @@ bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
   resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
 
-bitcoinjs-lib@^4, bitcoinjs-lib@^4.0.2:
+bitcoinjs-lib@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-4.0.2.tgz#84fc9d14774c07581ad1795f2444706fc3f7a666"
   integrity sha512-Y6AW91WPDoDQQLy4FejVoH4NvENqvMy+Q/8mnakEzckG1NXiLo0VgnEZyuvZb6lkhE2+YxzTCgpqzbnerOSpEg==
   dependencies:
     bech32 "^1.1.2"
     bip32 "^1.0.0"
+    bip66 "^1.1.0"
+    bitcoin-ops "^1.4.0"
+    bs58check "^2.0.0"
+    create-hash "^1.1.0"
+    create-hmac "^1.1.3"
+    merkle-lib "^2.0.10"
+    pushdata-bitcoin "^1.0.1"
+    randombytes "^2.0.1"
+    safe-buffer "^5.1.1"
+    tiny-secp256k1 "^1.0.0"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.0.4"
+    wif "^2.0.1"
+
+bitcoinjs-lib@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-4.0.5.tgz#2cce3469b950fade9f0442755ebb26bf9de519a1"
+  integrity sha512-gYs7K2hiY4Xb96J8AIF+Rx+hqbwjVlp5Zt6L6AnHOdzfe/2tODdmDxsEytnaxVCdhOUg0JnsGpl+KowBpGLxtA==
+  dependencies:
+    bech32 "^1.1.2"
+    bip32 "^1.0.4"
     bip66 "^1.1.0"
     bitcoin-ops "^1.4.0"
     bs58check "^2.0.0"


### PR DESCRIPTION
This PR fixes a bug where invalid STX transactions (valid BTC transaction but rejected by Stacks core node) shows up as a valid STX transaction in the wallet transaction history. This only occurs when the account has no prior transaction history.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @person1 or @person2
